### PR TITLE
Set a specific llvm-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Jauhien Piatlicki <jauhien@gentoo.org>"]
 
 [dependencies]
 docopt = "0.6"
-llvm-sys = "*"
+llvm-sys = "0.2.1"
 regex = "*"
 regex_macros = "*"
 rustc-serialize = "0.3"


### PR DESCRIPTION
The types in current versions of llvm-sys are not compatible with the llvm-sys (0.2.1) used by iron-llvm.